### PR TITLE
chore: polish cli and templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "memmap2",
  "rfd",
  "uuid",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rfd = "0.14"
 goblin = { version = "0.8", default-features = false, features = ["pe64", "std"] }
 memmap2 = "0.9"
 uuid = { version = "1", features = ["v4", "fast-rng"] }
+windows-sys = { version = "0.52", features = ["Win32_System_Console", "Win32_Foundation"] }
 
 [profile.release]
 opt-level = "z"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Rust rewrite this project. It inspects a DLL’s export table and generates the 
 - **2025-12-03 (Part 1)**: Added VS2026 templates (slnx/vcxproj/filters/user) alongside shared C/ASM templates; GUI supports generating VS2026 projects;
 - **2025-12-03 (Part 2)**: Generation now follows DLL architecture: x86 only emits proxy C; x64 emits C + jump ASM; VS2022/VS2026 templates trim configs/files per arch, filters/platforms adjust, nested placeholders resolve correctly, and x86 trampolines use `AHEADLIB_EXTERN` for C++ builds.
 - **2025-12-04**: Exports macro now derives from the project name (sanitized upper-case with `_EXPORTS` suffix), replacing the hardcoded `DLLTEST_EXPORTS`; both VS2022/VS2026 vcxproj templates inject the project-specific macro for x86/x64 builds.
+- **2025-12-07**: CLI polished (`aheadlibex-rs.exe <source|vs2022|vs2026> <dll_path> <output_dir>` with `--help`), GUI auto-detaches console on launch, templates normalized to four-space indents, and VS naming updated: solution `AheadlibEx_<DLL name>`, project uses the DLL name, outputs follow the new naming.
 
 
 ## Credits

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,71 @@
-#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
-
 mod dll;
 mod gui;
 mod ui_events;
 #[allow(dead_code)]
 mod templates;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
+use std::{env, path::PathBuf};
+use ui_events::{generate_cli, OutputTarget};
+
+#[cfg(windows)]
+use windows_sys::Win32::System::Console::FreeConsole;
+
+fn print_usage() {
+    println!("AheadLibEx usage:");
+    println!("  aheadlibex-rs.exe <source|vs2022|vs2026> <dll_path> <output_dir>");
+    println!("Examples:");
+    println!("  aheadlibex-rs.exe source  \"C:\\\\path\\\\to\\\\foo.dll\" \"C:\\\\path\\\\to\\\\out\"");
+    println!("  aheadlibex-rs.exe vs2022 \"C:\\\\path\\\\to\\\\foo.dll\" \"C:\\\\path\\\\to\\\\out\"");
+    println!("  aheadlibex-rs.exe vs2026 \"C:\\\\path\\\\to\\\\foo.dll\" \"C:\\\\path\\\\to\\\\out\"");
+    println!("No arguments -> GUI mode (console auto-detached on Windows).");
+}
+
+#[cfg(windows)]
+fn detach_console_if_needed(no_args: bool) {
+    if no_args {
+        // 双击启动默认会带个控制台，这里把它关掉，只保留 GUI
+        unsafe {
+            let _ = FreeConsole();
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn detach_console_if_needed(_no_args: bool) {}
 
 fn main() -> Result<()> {
-    gui::launch_gui()
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    if args.is_empty() {
+        detach_console_if_needed(true);
+        return gui::launch_gui();
+    }
+
+    if args.len() == 1 && matches!(args[0].as_str(), "-h" | "--help" | "help") {
+        print_usage();
+        return Ok(());
+    }
+
+    if args.len() != 3 {
+        bail!("Usage: AheadLibEx <source|vs2022|vs2026> <dll_path> <output_dir>");
+    }
+
+    let target = match args[0].to_ascii_lowercase().as_str() {
+        "source" | "src" | "c" => OutputTarget::Source,
+        "vs2022" | "2022" => OutputTarget::Vs2022,
+        "vs2026" | "2026" => OutputTarget::Vs2026,
+        other => bail!("Unknown target '{}'. Use source|vs2022|vs2026.", other),
+    };
+
+    let dll_path = PathBuf::from(&args[1]);
+    let output_dir = PathBuf::from(&args[2]);
+
+    let written = generate_cli(target, &dll_path, &output_dir)?;
+    println!("Generated {} file(s):", written.len());
+    for path in written {
+        println!("{path}");
+    }
+
+    Ok(())
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -119,17 +119,17 @@ fn prepare_exports(entries: &[ExportEntry]) -> Vec<PreparedExport<'_>> {
 fn solution_configs(is_x64: bool, project_guid: &str) -> (String, String) {
     if is_x64 {
         (
-            "\t\tDebug|x64 = Debug|x64\n\t\tRelease|x64 = Release|x64\n".to_string(),
+            "        Debug|x64 = Debug|x64\n        Release|x64 = Release|x64\n".to_string(),
             format!(
-                "\t\t{guid}.Debug|x64.ActiveCfg = Debug|x64\n\t\t{guid}.Debug|x64.Build.0 = Debug|x64\n\t\t{guid}.Release|x64.ActiveCfg = Release|x64\n\t\t{guid}.Release|x64.Build.0 = Release|x64\n",
+                "        {guid}.Debug|x64.ActiveCfg = Debug|x64\n        {guid}.Debug|x64.Build.0 = Debug|x64\n        {guid}.Release|x64.ActiveCfg = Release|x64\n        {guid}.Release|x64.Build.0 = Release|x64\n",
                 guid = project_guid
             ),
         )
     } else {
         (
-            "\t\tDebug|x86 = Debug|x86\n\t\tRelease|x86 = Release|x86\n".to_string(),
+            "        Debug|x86 = Debug|x86\n        Release|x86 = Release|x86\n".to_string(),
             format!(
-                "\t\t{guid}.Debug|x86.ActiveCfg = Debug|Win32\n\t\t{guid}.Debug|x86.Build.0 = Debug|Win32\n\t\t{guid}.Release|x86.ActiveCfg = Release|Win32\n\t\t{guid}.Release|x86.Build.0 = Release|Win32\n",
+                "        {guid}.Debug|x86.ActiveCfg = Debug|Win32\n        {guid}.Debug|x86.Build.0 = Debug|Win32\n        {guid}.Release|x86.ActiveCfg = Release|Win32\n        {guid}.Release|x86.Build.0 = Release|Win32\n",
                 guid = project_guid
             ),
         )
@@ -537,13 +537,13 @@ pub fn render_c(ctx: &VsTemplateContext) -> String {
         if exp.label.starts_with("Noname") {
             let _ = writeln!(
                 init_forwarders,
-                "\tpfnAheadLibEx_{} = get_address(MAKEINTRESOURCEA({}));",
+                "    pfnAheadLibEx_{} = get_address(MAKEINTRESOURCEA({}));",
                 exp.stub, exp.ordinal
             );
         } else {
             let _ = writeln!(
                 init_forwarders,
-                "\tpfnAheadLibEx_{} = get_address(\"{}\");",
+                "    pfnAheadLibEx_{} = get_address(\"{}\");",
                 exp.stub, exp.raw_name
             );
         }
@@ -592,13 +592,13 @@ pub fn render_c_x64(ctx: &VsTemplateContext) -> String {
         if exp.label.starts_with("Noname") {
             let _ = writeln!(
                 init_forwarders,
-                "\tpfnAheadLibEx_{} = get_address(MAKEINTRESOURCEA({}));",
+                "    pfnAheadLibEx_{} = get_address(MAKEINTRESOURCEA({}));",
                 exp.stub, exp.ordinal
             );
         } else {
             let _ = writeln!(
                 init_forwarders,
-                "\tpfnAheadLibEx_{} = get_address(\"{}\");",
+                "    pfnAheadLibEx_{} = get_address(\"{}\");",
                 exp.stub, exp.raw_name
             );
         }
@@ -627,7 +627,7 @@ pub fn render_asm_x64(ctx: &VsTemplateContext) -> String {
     for exp in &exports {
         let _ = writeln!(
             jumps,
-            "AheadLibEx_{name} PROC\n\tjmp pfnAheadLibEx_{name}\nAheadLibEx_{name} ENDP\n",
+            "AheadLibEx_{name} PROC\n    jmp pfnAheadLibEx_{name}\nAheadLibEx_{name} ENDP\n",
             name = exp.stub
         );
     }

--- a/templates/common/proxy_x64.c.tpl
+++ b/templates/common/proxy_x64.c.tpl
@@ -23,50 +23,50 @@ static HMODULE g_origin_module_handle;
 
 static VOID WINAPI free_origin_module(void)
 {
-	if (g_origin_module_handle)
-	{
-		FreeLibrary(g_origin_module_handle);
-		g_origin_module_handle = NULL;
-	}
+    if (g_origin_module_handle)
+    {
+        FreeLibrary(g_origin_module_handle);
+        g_origin_module_handle = NULL;
+    }
 }
 
 static BOOL WINAPI load_original_module(void)
 {
-	TCHAR module_path[MAX_PATH] = { 0 };
-	TCHAR message[MAX_PATH] = { 0 };
+    TCHAR module_path[MAX_PATH] = { 0 };
+    TCHAR message[MAX_PATH] = { 0 };
 
-	GetSystemDirectory(module_path, MAX_PATH);
-	lstrcat(module_path, TEXT("\\"));
-	lstrcat(module_path, TEXT("{{DLL_NAME}}"));
+    GetSystemDirectory(module_path, MAX_PATH);
+    lstrcat(module_path, TEXT("\\"));
+    lstrcat(module_path, TEXT("{{DLL_NAME}}"));
 
-	g_origin_module_handle = LoadLibrary(module_path);
-	if (!g_origin_module_handle)
-	{
-		wsprintf(message, TEXT("Cannot locate %s, AheadLibEx cannot continue.\nerror code:0x%08X"), module_path, GetLastError());
-		MessageBox(NULL, message, TEXT("AheadLibEx"), MB_ICONSTOP);
-	}
+    g_origin_module_handle = LoadLibrary(module_path);
+    if (!g_origin_module_handle)
+    {
+        wsprintf(message, TEXT("Cannot locate %s, AheadLibEx cannot continue.\nerror code:0x%08X"), module_path, GetLastError());
+        MessageBox(NULL, message, TEXT("AheadLibEx"), MB_ICONSTOP);
+    }
 
-	return g_origin_module_handle != NULL;
+    return g_origin_module_handle != NULL;
 }
 
 static FARPROC WINAPI get_address(PCSTR proc_name)
 {
-	CHAR ordinal_name[64];
-	TCHAR message[MAX_PATH];
-	FARPROC address = GetProcAddress(g_origin_module_handle, proc_name);
-	if (!address)
-	{
-		if (HIWORD(proc_name) == 0)
-		{
-			wsprintfA(ordinal_name, "#%d", proc_name);
-			proc_name = ordinal_name;
-		}
-		wsprintf(message, TEXT("Cannot locate export %hs."), proc_name);
-		MessageBox(NULL, message, TEXT("AheadLibEx"), MB_ICONSTOP);
+    CHAR ordinal_name[64];
+    TCHAR message[MAX_PATH];
+    FARPROC address = GetProcAddress(g_origin_module_handle, proc_name);
+    if (!address)
+    {
+        if (HIWORD(proc_name) == 0)
+        {
+            wsprintfA(ordinal_name, "#%d", proc_name);
+            proc_name = ordinal_name;
+        }
+        wsprintf(message, TEXT("Cannot locate export %hs."), proc_name);
+        MessageBox(NULL, message, TEXT("AheadLibEx"), MB_ICONSTOP);
 
-		ExitProcess(0);
-	}
-	return address;
+        ExitProcess(0);
+    }
+    return address;
 }
 
 static VOID WINAPI init_forwarders(void)
@@ -76,34 +76,34 @@ static VOID WINAPI init_forwarders(void)
 
 DWORD WINAPI patch_thread_proc(LPVOID context)
 {
-	UNREFERENCED_PARAMETER(context);
-	// TODO: Put custom patch logic here when the target process matches.
-	MessageBox(NULL, TEXT("AheadLibExTest!"), TEXT("AheadLibEx"), MB_OK);
-	return 0;
+    UNREFERENCED_PARAMETER(context);
+    // TODO: Put custom patch logic here when the target process matches.
+    MessageBox(NULL, TEXT("AheadLibExTest!"), TEXT("AheadLibEx"), MB_OK);
+    return 0;
 }
 
 BOOL APIENTRY DllMain(HMODULE module, DWORD reason, PVOID reserved)
 {
-	UNREFERENCED_PARAMETER(reserved);
-	if (reason == DLL_PROCESS_ATTACH)
-	{
-		DisableThreadLibraryCalls(module);
-		if (!load_original_module())
-		{
-			return FALSE;
-		}
-		init_forwarders();
+    UNREFERENCED_PARAMETER(reserved);
+    if (reason == DLL_PROCESS_ATTACH)
+    {
+        DisableThreadLibraryCalls(module);
+        if (!load_original_module())
+        {
+            return FALSE;
+        }
+        init_forwarders();
 
-		// TODO: your patch process begins here.
-		HANDLE thread = CreateThread(NULL, 0, patch_thread_proc, NULL, 0, NULL);
-		if (thread)
-		{
-			CloseHandle(thread);
-		}
-	}
-	else if (reason == DLL_PROCESS_DETACH)
-	{
-		free_origin_module();
-	}
-	return TRUE;
+        // TODO: your patch process begins here.
+        HANDLE thread = CreateThread(NULL, 0, patch_thread_proc, NULL, 0, NULL);
+        if (thread)
+        {
+            CloseHandle(thread);
+        }
+    }
+    else if (reason == DLL_PROCESS_DETACH)
+    {
+        free_origin_module();
+    }
+    return TRUE;
 }

--- a/templates/common/proxy_x86.c.tpl
+++ b/templates/common/proxy_x86.c.tpl
@@ -23,50 +23,50 @@ static HMODULE g_origin_module_handle;
 
 static VOID WINAPI free_origin_module(void)
 {
-	if (g_origin_module_handle)
-	{
-		FreeLibrary(g_origin_module_handle);
-		g_origin_module_handle = NULL;
-	}
+    if (g_origin_module_handle)
+    {
+        FreeLibrary(g_origin_module_handle);
+        g_origin_module_handle = NULL;
+    }
 }
 
 static BOOL WINAPI load_original_module(void)
 {
-	TCHAR module_path[MAX_PATH] = { 0 };
-	TCHAR message[MAX_PATH] = { 0 };
+    TCHAR module_path[MAX_PATH] = { 0 };
+    TCHAR message[MAX_PATH] = { 0 };
 
-	GetSystemDirectory(module_path, MAX_PATH);
-	lstrcat(module_path, TEXT("\\"));
-	lstrcat(module_path, TEXT("{{DLL_NAME}}"));
+    GetSystemDirectory(module_path, MAX_PATH);
+    lstrcat(module_path, TEXT("\\"));
+    lstrcat(module_path, TEXT("{{DLL_NAME}}"));
 
-	g_origin_module_handle = LoadLibrary(module_path);
-	if (!g_origin_module_handle)
-	{
-		wsprintf(message, TEXT("Cannot locate %s, AheadLibEx cannot continue.\nerror code:0x%08X"), module_path, GetLastError());
-		MessageBox(NULL, message, TEXT("AheadLibEx"), MB_ICONSTOP);
-	}
+    g_origin_module_handle = LoadLibrary(module_path);
+    if (!g_origin_module_handle)
+    {
+        wsprintf(message, TEXT("Cannot locate %s, AheadLibEx cannot continue.\nerror code:0x%08X"), module_path, GetLastError());
+        MessageBox(NULL, message, TEXT("AheadLibEx"), MB_ICONSTOP);
+    }
 
-	return g_origin_module_handle != NULL;
+    return g_origin_module_handle != NULL;
 }
 
 static FARPROC WINAPI get_address(PCSTR proc_name)
 {
-	CHAR ordinal_name[64];
-	TCHAR message[MAX_PATH];
-	FARPROC address = GetProcAddress(g_origin_module_handle, proc_name);
-	if (!address)
-	{
-		if (HIWORD(proc_name) == 0)
-		{
-			wsprintfA(ordinal_name, "#%d", proc_name);
-			proc_name = ordinal_name;
-		}
-		wsprintf(message, TEXT("Cannot locate export %hs."), proc_name);
-		MessageBox(NULL, message, TEXT("AheadLibEx"), MB_ICONSTOP);
+    CHAR ordinal_name[64];
+    TCHAR message[MAX_PATH];
+    FARPROC address = GetProcAddress(g_origin_module_handle, proc_name);
+    if (!address)
+    {
+        if (HIWORD(proc_name) == 0)
+        {
+            wsprintfA(ordinal_name, "#%d", proc_name);
+            proc_name = ordinal_name;
+        }
+        wsprintf(message, TEXT("Cannot locate export %hs."), proc_name);
+        MessageBox(NULL, message, TEXT("AheadLibEx"), MB_ICONSTOP);
 
-		ExitProcess(0);
-	}
-	return address;
+        ExitProcess(0);
+    }
+    return address;
 }
 
 static VOID WINAPI init_forwarders(void)
@@ -76,34 +76,34 @@ static VOID WINAPI init_forwarders(void)
 
 DWORD WINAPI patch_thread_proc(LPVOID context)
 {
-	UNREFERENCED_PARAMETER(context);
-	// TODO: Put custom patch logic here when the target process matches.
-	MessageBox(NULL, TEXT("AheadLibExTest!"), TEXT("AheadLibEx"), MB_OK);
-	return 0;
+    UNREFERENCED_PARAMETER(context);
+    // TODO: Put custom patch logic here when the target process matches.
+    MessageBox(NULL, TEXT("AheadLibExTest!"), TEXT("AheadLibEx"), MB_OK);
+    return 0;
 }
 
 BOOL APIENTRY DllMain(HMODULE module, DWORD reason, PVOID reserved)
 {
-	UNREFERENCED_PARAMETER(reserved);
-	if (reason == DLL_PROCESS_ATTACH)
-	{
-		DisableThreadLibraryCalls(module);
-		if (!load_original_module())
-		{
-			return FALSE;
-		}
-		init_forwarders();
+    UNREFERENCED_PARAMETER(reserved);
+    if (reason == DLL_PROCESS_ATTACH)
+    {
+        DisableThreadLibraryCalls(module);
+        if (!load_original_module())
+        {
+            return FALSE;
+        }
+        init_forwarders();
 
-		// TODO: your patch process begins here.
-		HANDLE thread = CreateThread(NULL, 0, patch_thread_proc, NULL, 0, NULL);
-		if (thread)
-		{
-			CloseHandle(thread);
-		}
-	}
-	else if (reason == DLL_PROCESS_DETACH)
-	{
-		free_origin_module();
-	}
-	return TRUE;
+        // TODO: your patch process begins here.
+        HANDLE thread = CreateThread(NULL, 0, patch_thread_proc, NULL, 0, NULL);
+        if (thread)
+        {
+            CloseHandle(thread);
+        }
+    }
+    else if (reason == DLL_PROCESS_DETACH)
+    {
+        free_origin_module();
+    }
+    return TRUE;
 }

--- a/templates/vs2022/vs2022_solution.sln.tpl
+++ b/templates/vs2022/vs2022_solution.sln.tpl
@@ -9,16 +9,16 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "{{PROJECT_NAME}}", "{{PROJECT_NAME}}.vcxproj", "{{PROJECT_GUID}}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
 {{SOLUTION_CONFIGS}}
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
 {{PROJECT_CONFIGS}}
-	EndGlobalSection
- 	GlobalSection(SolutionProperties) = preSolution
- 		HideSolutionNode = FALSE 
-	EndGlobalSection 
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {{SOLUTION_GUID}}
-	EndGlobalSection
+    EndGlobalSection
+     GlobalSection(SolutionProperties) = preSolution
+         HideSolutionNode = FALSE 
+    EndGlobalSection 
+    GlobalSection(ExtensibilityGlobals) = postSolution
+        SolutionGuid = {{SOLUTION_GUID}}
+    EndGlobalSection
 EndGlobal


### PR DESCRIPTION
  ## Summary
  - add CLI help flag and detach console when launching GUI on Windows
  - normalize VS solution/project naming (solution AheadlibEx_<DLL>, project uses DLL name)
  - unify template indentation to four spaces and clean naming in generated files

  ## Testing
  - cargo build --release
  - manual: ran `aheadlibex-rs.exe vs2022 "$env:SystemRoot\System32\version.dll" "$PWD"` to ensure generation succeeds