### PR TITLE
Fix x64 /EXPORT pragma quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Rust rewrite this project. It inspects a DLL’s export table and generates the 
 - **2025-12-04**: Exports macro now derives from the project name (sanitized upper-case with `_EXPORTS` suffix), replacing the hardcoded `DLLTEST_EXPORTS`; both VS2022/VS2026 vcxproj templates inject the project-specific macro for x86/x64 builds.
 - **2025-12-07**: CLI polished (`aheadlibex-rs.exe <source|vs2022|vs2026> <dll_path> <output_dir>` with `--help`), GUI auto-detaches console on launch, templates normalized to four-space indents, and VS naming updated: solution `AheadlibEx_<DLL name>`, project uses the DLL name, outputs follow the new naming.
 - **2025-12-08**: Restructured codebase into enterprise-style layers (`domain`, `application`, `infrastructure`, `presentation`) with public re-exports; template includes now use `CARGO_MANIFEST_DIR` to keep paths stable after refactors; CLI banner aligns with GUI branding.
-
+- **2026-02-01**: Fixed x64 generated `#pragma comment(linker, "/EXPORT:...")` quote escaping.
 
 ## Credits
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,6 +25,7 @@ Rust 重写的 AheadLibEx，用于解析 DLL 导出表并生成代理源码，�
 - **2025-12-04**：导出宏来源改为项目名（大写+`_EXPORTS`），VS 模板注入宏。
 - **2025-12-07**：CLI 完善（参数/帮助），GUI 启动自动分离控制台，模板统一四空格，VS 命名规范化。
 - **2025-12-08**：分层为 enterprise-style（domain/application/infrastructure/presentation）并再导出；模板 include 改用 `CARGO_MANIFEST_DIR`；CLI banner 与 GUI 品牌对齐。
+- **2026-02-01**：修正 x64 生成的 `#pragma comment(linker, "/EXPORT:...")` 引号转义。
 
 ## 运行
 - GUI：直接双击可启动（Windows Release 无控制台闪烁）。

--- a/src/infrastructure/templates.rs
+++ b/src/infrastructure/templates.rs
@@ -540,8 +540,12 @@ pub fn render_c(ctx: &VsTemplateContext) -> String {
         } else {
             ""
         };
-        let entry = format!("\"{}=_AheadLibEx_{},@{}{}\"", exp.label, exp.stub, exp.ordinal, noname);
-        let _ = writeln!(export_pragmas, "#pragma comment(linker, \"/EXPORT:{}\")", entry);
+        let entry = format!("{}=_AheadLibEx_{},@{}{}", exp.label, exp.stub, exp.ordinal, noname);
+        let _ = writeln!(
+            export_pragmas,
+            "#pragma comment(linker, \"/EXPORT:\\\"{}\\\"\")",
+            entry
+        );
     }
 
     let mut forward_decls = String::new();
@@ -601,8 +605,12 @@ pub fn render_c_x64(ctx: &VsTemplateContext) -> String {
         } else {
             ""
         };
-        let entry = format!("\"{}=AheadLibEx_{},@{}{}\"", exp.label, exp.stub, exp.ordinal, noname);
-        let _ = writeln!(export_pragmas, "#pragma comment(linker, \"/EXPORT:{}\")", entry);
+        let entry = format!("{}=AheadLibEx_{},@{}{}", exp.label, exp.stub, exp.ordinal, noname);
+        let _ = writeln!(
+            export_pragmas,
+            "#pragma comment(linker, \"/EXPORT:\\\"{}\\\"\")",
+            entry
+        );
     }
 
     let mut forward_decls = String::new();

--- a/tests/templates_decorated.rs
+++ b/tests/templates_decorated.rs
@@ -48,16 +48,16 @@ fn decorated_names_are_preserved_in_exports() {
     let ctx = dummy_ctx(&exports);
 
     let c_x86 = render_c(&ctx);
-    assert!(c_x86.contains(r#"/EXPORT:"?Func@@YAXH@Z=_AheadLibEx__Func__YAXH_Z,@1""#));
-    assert!(c_x86.contains(r#"/EXPORT:"@Func@8=_AheadLibEx__Func_8,@2""#));
-    assert!(c_x86.contains(r#"/EXPORT:"??0Class@@QAE@XZ=_AheadLibEx___0Class__QAE_XZ,@3""#));
-    assert!(c_x86.contains(r#"/EXPORT:"Noname345=_AheadLibEx_Unnamed345,@345,NONAME""#));
+    assert!(c_x86.contains(r#"/EXPORT:\"?Func@@YAXH@Z=_AheadLibEx__Func__YAXH_Z,@1\""#));
+    assert!(c_x86.contains(r#"/EXPORT:\"@Func@8=_AheadLibEx__Func_8,@2\""#));
+    assert!(c_x86.contains(r#"/EXPORT:\"??0Class@@QAE@XZ=_AheadLibEx___0Class__QAE_XZ,@3\""#));
+    assert!(c_x86.contains(r#"/EXPORT:\"Noname345=_AheadLibEx_Unnamed345,@345,NONAME\""#));
 
     let c_x64 = render_c_x64(&ctx);
-    assert!(c_x64.contains(r#"/EXPORT:"?Func@@YAXH@Z=AheadLibEx__Func__YAXH_Z,@1""#));
-    assert!(c_x64.contains(r#"/EXPORT:"@Func@8=AheadLibEx__Func_8,@2""#));
-    assert!(c_x64.contains(r#"/EXPORT:"??0Class@@QAE@XZ=AheadLibEx___0Class__QAE_XZ,@3""#));
-    assert!(c_x64.contains(r#"/EXPORT:"Noname345=AheadLibEx_Unnamed345,@345,NONAME""#));
+    assert!(c_x64.contains(r#"/EXPORT:\"?Func@@YAXH@Z=AheadLibEx__Func__YAXH_Z,@1\""#));
+    assert!(c_x64.contains(r#"/EXPORT:\"@Func@8=AheadLibEx__Func_8,@2\""#));
+    assert!(c_x64.contains(r#"/EXPORT:\"??0Class@@QAE@XZ=AheadLibEx___0Class__QAE_XZ,@3\""#));
+    assert!(c_x64.contains(r#"/EXPORT:\"Noname345=AheadLibEx_Unnamed345,@345,NONAME\""#));
 }
 
 #[test]


### PR DESCRIPTION
 ## SUMMARY
  Fix x64 `/EXPORT` linker pragma generation by correctly escaping quotes so ordinals like `@1` stay inside the string
  literal (prevents MSVC `error C2018: unknown character 0x40`). Update template output tests and record the fix in the
  README Refactor Timeline.

  ## TESTING
  `cargo test`